### PR TITLE
[Super minor] Hyperlink pointing to wrong repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A SNES emulator for the N64, written in assembly.
 The goal of sodium64 is to be fast and accurate enough to at least get some SNES games playable on the N64. It does its rendering entirely on the RSP in an attempt to reduce load on the main CPU. I thought it would be fun to write something specifically for older hardware in assembly, so sodium64 was born! It's still in very early stages, so don't expect much.
 
 ### Downloads
-Automatic builds of the latest sodium64 commit are provided via GitHub Actions; you can download them on the [releases page](https://github.com/Hydr8gon/NooDS/releases).
+Automatic builds of the latest sodium64 commit are provided via GitHub Actions; you can download them on the [releases page](https://github.com/Hydr8gon/sodium64/releases).
 
 ### Usage
 Place SNES ROMs with extension `.sfc`/`.smc` in the same folder as `sodium64.z64` and `rom-converter.py`. Run `rom-converter.py` using [Python](https://www.python.org) to convert the SNES ROMs to N64 ROMs. The output ROMs will be in a new folder called `out`.


### PR DESCRIPTION
I noticed a hyperlink meant for sodium64 pointing to NooDS repo. Super minor, but could go unnoticed for a while if no one points it out.