### PR TITLE
Fix rom-converter.py crashing on Windows

### DIFF
--- a/rom-converter.py
+++ b/rom-converter.py
@@ -30,6 +30,7 @@ for filename in os.listdir("."):
         outFile.write(baseFile.read())
         outFile.seek(0x200000, 0)
         outFile.write(inFile.read())
+        inFile.close()
 
 if convert == 1:
     print("\nA header or .sfc extension was detected in one or more ROMs.")


### PR DESCRIPTION
On Windows, rom-converter.py crashes during the .sfc -> .smc conversion step on line 50 (`os.remove(filename`) with a `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`.

This is because on Windows, it's illegal to remove a file while its handle is still being used somewhere. The use occurs earlier in the script where `inFile` handle is acquired but it's never explicitly closed. Adding a `inFile.close()` to line 33 fixes this Windows issue.